### PR TITLE
fix: migrate actions by policy

### DIFF
--- a/actions/helm-deploy/README.md
+++ b/actions/helm-deploy/README.md
@@ -1,0 +1,165 @@
+# Helm Deploy 2060 – GitHub Action
+
+This GitHub Action detects changed Helm values files and deploys Helm charts accordingly. It supports multi-environment deployments (`dev`, `prod`), dynamic release detection, and optional overrides for production environments.
+
+## Use Case
+
+Deploy Helm charts only when values or override files change, with environment-aware customization.
+
+---
+
+## Usage
+
+```yaml
+- name: Helm Deploy
+  uses: 2060-io/devops/actions/helm-deploy@main
+  with:
+    environment: dev
+    namespace: my-namespace
+    valuesDir: values
+    domain: mydomain.com
+```
+
+### Trigger only on changes (suggested)
+
+In your workflow, you might combine this with a conditional or path filter for performance:
+
+```yaml
+on:
+  push:
+    paths:
+      - 'values/**'
+      - 'pro/**'
+```
+
+---
+
+## Inputs
+
+| Name           | Required | Description                                                       |
+| -------------- | -------- | ----------------------------------------------------------------- |
+| `environment`  | Yes    | Deployment environment. Must be either `dev` or `prod`.           |
+| `namespace`    | Yes    | Kubernetes namespace to deploy into.                              |
+| `valuesDir`    | Yes    | Directory where Helm values files are stored. Example: `values/`  |
+| `overridesDir` | No     | Directory for environment-specific overrides. Required in `prod`. |
+| `domain`       | No     | Passed as `--set global.domain=...` during Helm install/upgrade.  |
+| `release`      | No     | Explicit release to deploy, bypassing change detection.           |
+
+---
+
+## How It Works
+
+### 1. Validate Inputs
+
+Ensures `environment`, `namespace`, and `valuesDir` are defined and that `overridesDir` is provided in non-`dev` environments.
+
+### 2. Detect Changed Files
+
+* If `release` is provided: deploy only that one.
+* Otherwise:
+
+  * Scans changed `.yaml` files in `valuesDir` and (if `prod`) `overridesDir`.
+  * Computes base filenames to identify which Helm releases changed.
+
+### 3. Deploy Using Helm
+
+For each detected release:
+
+* Extracts `chartSource` and `chartVersion` from the YAML.
+* Applies overrides if present.
+* Sets `global.domain` if provided.
+* Executes `helm upgrade --install`.
+
+---
+
+## Example File Structure
+
+```
+values/
+├── service-a.yaml   # chartSource: ./charts/service-a
+├── service-b.yaml   # chartSource: ./charts/service-b
+
+pro/
+├── service-a.yaml   # Production overrides
+
+charts/
+└── service-a/
+```
+
+---
+
+## Example YAML Value File
+
+```yaml
+chartSource: ./charts/service-a
+chartVersion: 1.2.3
+chartSecrets:
+  - name: DB_PASSWORD        # GitHub Actions secret name
+    path: app.config.dbPassword
+  - name: API_KEY
+    path: app.config.apiKey
+
+replicaCount: 2
+image:
+  repository: myrepo/service-a
+  tag: latest
+```
+
+## How Secrets Are Used
+
+* The `chartSecrets` section does **not** contain actual secret values, only mappings (`name` → `path`).
+* GitHub Actions secrets (e.g., `DB_PASSWORD`, `API_KEY`, `EMAIL_PASS`, `TESTING`) must be defined under **Settings → Secrets and variables → Actions** in your repository.
+* During deployment, these secrets are exported as **environment variables** (e.g. `$DB_PASSWORD`, `$API_KEY`) and then mapped dynamically according to the `chartSecrets` configuration.
+* At runtime, the script resolves them and generates Helm arguments such as:
+
+```bash
+--set app.config.dbPassword=$DB_PASSWORD \
+--set app.config.apiKey=$API_KEY \
+--set name=$EMAIL_PASS \
+--set app.config.testing=$TESTING
+```
+
+This ensures secrets are securely injected at deployment time without being exposed in your repository or action inputs.
+
+---
+
+### Usage with secrets
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Helm Deploy
+        uses: 2060-io/devops/actions/helm-deploy@main
+        with:
+          environment: dev
+          namespace: my-namespace
+          valuesDir: values
+          domain: mydomain.com
+        env:
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          API_KEY: ${{ secrets.API_KEY }}
+          EMAIL_PASS: ${{ secrets.EMAIL_PASS }}
+          TESTING: ${{ secrets.TESTING }}
+```
+
+---
+
+## Best Practices
+
+* Store sensitive data (e.g., Helm credentials) as [GitHub Secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets).
+
+---
+
+## Repo Structure
+
+```text
+.github/
+└── actions/
+    └── helm-deploy-2060/
+        ├── action.yml
+        └── README.md
+```

--- a/actions/helm-deploy/action.yml
+++ b/actions/helm-deploy/action.yml
@@ -1,0 +1,160 @@
+name: Helm Deploy 2060
+description: Detects changed charts and deploys using Helm with optional environment overrides
+inputs:
+  environment:
+    required: true
+    description: The deployment environment (e.g. dev, prod)
+  namespace:
+    required: true
+    description: The Kubernetes namespace to deploy into
+  valuesDir:
+    required: true
+    description: Path to the base values directory (e.g. values)
+  overridesDir:
+    required: false
+    description: Path to the overrides directory (e.g. pro). Only used in prod
+  domain:
+    required: false
+    description: The global domain to set as --set global.domain
+  release:
+    required: false
+    description: Optional release name to deploy directly
+  dryRun:
+    required: false
+    description: If true, performs a dry-run of the deployment
+    default: 'false'
+runs:
+  using: "composite"
+  steps:
+    - name: Validate required inputs
+      shell: bash
+      env:
+        ENVIRONMENT: ${{ inputs.environment }}
+        NAMESPACE: ${{ inputs.namespace }}
+        VALUES_DIR: ${{ inputs.valuesDir }}
+        OVERRIDES_DIR: ${{ inputs.overridesDir }}
+      run: |
+        MISSING=()
+        [[ -z "$ENVIRONMENT" ]] && MISSING+=("environment")
+        [[ -z "$NAMESPACE" ]] && MISSING+=("namespace")
+        [[ -z "$VALUES_DIR" ]] && MISSING+=("valuesDir")
+
+        if [[ ${#MISSING[@]} -ne 0 ]]; then
+          echo "Missing required input(s): ${MISSING[*]}"
+          exit 1
+        fi
+
+        if [[ "$ENVIRONMENT" != "dev" && "$ENVIRONMENT" != "prod" ]]; then
+          echo "Invalid value for 'environment': '$ENVIRONMENT'. Must be 'dev' or 'prod'."
+          exit 1
+        fi
+
+        if [[ "$ENVIRONMENT" != "dev" && -z "$OVERRIDES_DIR" ]]; then
+          echo "'overridesDir' must be defined when environment is not 'dev'."
+          exit 1
+        fi
+
+
+    - name: Detect changed value files
+      id: changed_files
+      shell: bash
+      run: |
+        if [[ "${{ inputs.release }}" != "" ]]; then
+          FILES="${{ inputs.valuesDir }}/${{ inputs.release }}.yaml"
+        else
+          if [[ "${{ inputs.environment }}" != "dev" ]]; then
+            CHANGED_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -E '^${{ inputs.valuesDir }}/.*\.yaml|^${{ inputs.overridesDir }}/.*\.yaml' || true)
+            BASENAMES=$(echo "$CHANGED_FILES" | sed -E "s@^(${{ inputs.valuesDir }}|${{ inputs.overridesDir }})/@@" | sed 's/\.yaml$//' | sort -u)
+          else
+            CHANGED_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -E '^${{ inputs.valuesDir }}/.*\.yaml' || true)
+            BASENAMES=$(echo "$CHANGED_FILES" | sed -E "s@^${{ inputs.valuesDir }}/@@" | sed 's/\.yaml$//' | sort -u)
+          fi
+          FILES=$(for base in $BASENAMES; do echo "${{ inputs.valuesDir }}/$base.yaml"; done | paste -sd ',' -)
+        fi
+        echo "files=$FILES" >> $GITHUB_OUTPUT
+
+    - name: Install yq
+      uses: Makepad-fr/setup-yq-action@main
+      with:
+        version: '4.6.0'
+
+    - name: Deploy charts using Helm
+      if: steps.changed_files.outputs.files != ''
+      shell: bash
+      run: |
+        DRY_RUN_FLAG=""
+        if [[ "${{ inputs.dryRun }}" == "true" ]]; then
+          echo "Dry-run mode enabled. Validating Helm chart for $RELEASE"
+          DRY_RUN_FLAG="--dry-run --debug"
+        fi
+
+        IFS=',' read -ra FILES <<< "${{ steps.changed_files.outputs.files }}"
+        for file in "${FILES[@]}"; do
+          RELEASE=$(basename "$file" .yaml)
+          echo "Deploying $RELEASE using $file"
+
+          CHART_SOURCE=$(yq e '.chartSource' "$file")
+          CHART_VERSION=$(yq e '.chartVersion' "$file")
+
+          if [[ -z "$CHART_SOURCE" ]]; then
+            echo "Error: 'chartSource' is missing in $file"
+            exit 1
+          fi
+          if [[ -z "$CHART_VERSION" ]]; then
+            echo "Error: 'chartVersion' is missing in $file"
+            exit 1
+          fi
+
+          # If override file exists and overridesDir was provided
+          OVERRIDE_ARG=""
+          if [[ "${{ inputs.environment }}" == "prod" && -n "${{ inputs.overridesDir }}" ]]; then
+            OVERRIDE_FILE="${{ inputs.overridesDir }}/$RELEASE.yaml"
+            if [[ -f "$OVERRIDE_FILE" ]]; then
+              echo "Override file found: $OVERRIDE_FILE"
+              OVERRIDE_ARG="-f $OVERRIDE_FILE"
+            fi
+          fi
+
+          if [ "${{ inputs.domain }}" != "" ]; then
+            DOMAIN_ARG="--set global.domain=${{ inputs.domain }}"
+          else
+            DOMAIN_ARG=""
+            echo "No domain provided. Skipping --set global.domain"
+          fi
+
+          # Search chartSecrets on yaml file and replace it with --set
+          SECRET_ARGS=""
+          SECRET_COUNT=$(yq e '.chartSecrets | length' "$file")
+          if [[ "$SECRET_COUNT" -gt 0 ]]; then
+            echo "Processing $SECRET_COUNT secrets from $file"
+            for i in $(seq 0 $((SECRET_COUNT - 1))); do
+              SECRET_NAME=$(yq e ".chartSecrets[$i].name" "$file")
+              SECRET_PATH=$(yq e ".chartSecrets[$i].path" "$file")
+
+              if [[ -z "$SECRET_NAME" || -z "$SECRET_PATH" ]]; then
+                echo "Invalid secret entry in $file (index $i)"
+                exit 1
+              fi
+
+              echo "Mapping secret $SECRET_NAME to path $SECRET_PATH"
+              SECRET_VALUE=$(printenv "$SECRET_NAME")
+              if [[ -z "$SECRET_VALUE" ]]; then
+                echo "Secret $SECRET_NAME not found in environment variables"
+                exit 1
+              fi
+
+              SECRET_ARGS="$SECRET_ARGS --set $SECRET_PATH=$SECRET_VALUE"
+            done
+          fi
+
+          echo "Installing chart from: $CHART_SOURCE"
+          helm upgrade --install "$RELEASE" "$CHART_SOURCE" \
+            --version "$CHART_VERSION" \
+            -f "$file" \
+            $OVERRIDE_ARG \
+            $DOMAIN_ARG \
+            $SECRET_ARGS \
+            --namespace "${{ inputs.namespace }}" \
+            --create-namespace \
+            $DRY_RUN_FLAG
+        done

--- a/actions/pnpm-deploy/README.md
+++ b/actions/pnpm-deploy/README.md
@@ -1,0 +1,100 @@
+# Publish pnpm Libraries Deployment Workflow
+
+## Overview
+
+The **Publish pnpm Libraries Deployment** workflow is designed to automate the process of packaging and publishing one or more NPM packages managed with **pnpm**. It sets the release version in `package.json`, installs dependencies, and publishes the packages to the NPM registry.
+
+The workflow also supports a **dry-run mode**, which outputs the commands that would be executed without performing any actions.
+
+---
+
+## Inputs
+
+The workflow requires the following inputs:
+
+| Name              | Required | Default | Description                                                               |
+| ----------------- | -------- | ------- | ------------------------------------------------------------------------- |
+| `release-version` | Yes      | —       | The version to set in `package.json` files (e.g., `1.2.3`).               |
+| `npm-token`       | Yes      | —       | NPM authentication token used to publish packages to the registry.        |
+| `dry-run`         | No       | `false` | If set to `true`, the workflow only prints commands instead of executing. |
+
+---
+
+## Workflow Steps
+
+### 1. Setup Node.js
+
+* **Action**: [actions/setup-node@v4](https://github.com/actions/setup-node)
+* **Version**: Node.js 22
+* **Condition**: Runs only if `dry-run` is not enabled.
+
+### 2. Enable Corepack for pnpm
+
+* **Command**: `corepack enable`
+* **Condition**: Runs only if `dry-run` is not enabled.
+
+### 3. Install Dependencies
+
+* **Command**: `pnpm install`
+* **Condition**: Runs only if `dry-run` is not enabled.
+
+### 4. Set Release Version
+
+* **Command**:
+
+  ```bash
+  pnpm -r --topological version "${{ inputs.release-version }}"
+  ```
+* **Condition**: Runs only if `dry-run` is not enabled.
+
+### 5. Publish Packages
+
+* **Authentication**: Uses `NPM_AUTH_TOKEN` from `npm-token` input.
+* **Commands**:
+
+  ```bash
+  echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ~/.npmrc
+  pnpm config set npmAuthToken ${NPM_AUTH_TOKEN}
+  pnpm -r publish --no-git-checks --access public
+  ```
+* **Condition**: Runs only if `dry-run` is not enabled.
+
+### 6. Dry-Run Mode
+
+If `dry-run` is set to `true`, the workflow will not execute any publishing steps. Instead, it will print the commands that would have been executed.
+
+Example output:
+
+```
+Dry run mode enabled
+Would run with release version: 1.2.3
+Commands that would be executed:
+  corepack enable
+  pnpm install
+  pnpm -r --topological version "1.2.3"
+  pnpm -r publish --no-git-checks --access public
+```
+
+---
+
+## Usage Example
+
+To call this workflow from another workflow in the same repository, reference it as follows:
+
+```yaml
+jobs:
+  publish:
+    uses: ./.github/workflows/publish-pnpm-libraries.yml
+    with:
+      release-version: "1.2.3"
+      npm-token: ${{ secrets.NPM_TOKEN }}
+      dry-run: "false"
+```
+
+---
+
+## Notes
+
+* Ensure that `NPM_TOKEN` is stored as a secret in your repository or organization settings.
+* The workflow assumes the project is managed using **pnpm workspaces**.
+* Dry-run mode is useful for validating release commands before performing an actual publish.

--- a/actions/pnpm-deploy/action.yml
+++ b/actions/pnpm-deploy/action.yml
@@ -1,0 +1,61 @@
+name: Publish pnpm libraries deployment
+description: Package and publish one or more Helm charts to Docker Hub OCI registry
+
+inputs:
+  release-version:
+    description: The version to set in package.json (e.g. 1.2.3)
+    required: true
+  npm-token:
+    description: NPM token for authentication
+    required: true
+  dry-run:
+    description: If true, only print commands instead of executing
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup node v22
+      if: inputs.dry-run != 'true'
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22
+
+    - name: Corepack pnpm
+      if: inputs.dry-run != 'true'
+      run: corepack enable
+      shell: bash
+
+    - name: Install dependencies
+      if: inputs.dry-run != 'true'
+      run: pnpm install
+      shell: bash
+
+    - name: Set version for apps and packages
+      if: inputs.dry-run != 'true'
+      run: pnpm -r --topological version "${{ inputs.release-version }}"
+      shell: bash
+
+    - name: Publish NPM packages
+      if: inputs.dry-run != 'true'
+      env:
+        NPM_AUTH_TOKEN: ${{ inputs.npm-token }}
+      run: |
+        echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ~/.npmrc
+        pnpm config set npmAuthToken ${NPM_AUTH_TOKEN}
+        pnpm -r publish --no-git-checks --access public
+      shell: bash
+
+    # Dry-run mode
+    - name: Dry-run (print commands)
+      if: inputs.dry-run == 'true'
+      run: |
+        echo "Dry run mode enabled"
+        echo "Would run with release version: ${{ inputs.release-version }}"
+        echo "Commands that would be executed:"
+        echo "  corepack enable"
+        echo "  pnpm install"
+        echo "  pnpm -r --topological version \"${{ inputs.release-version }}\""
+        echo "  pnpm -r publish --no-git-checks --access public"
+      shell: bash

--- a/actions/publish-helm/README.md
+++ b/actions/publish-helm/README.md
@@ -1,0 +1,122 @@
+# Publish Helm Charts Action
+
+This GitHub Action packages and publishes one or more [Helm](https://helm.sh/) charts to the **Docker Hub OCI registry**.
+It supports both **independent charts** and **dependent charts** that reference each other within the same repository.
+
+---
+
+## Requirements
+
+Before using this Action, ensure the following requirements are met:
+
+1. **Helm CLI** must be available on the runner (the action itself installs Helm if missing).
+2. A **Docker Hub account** with permissions to push to your Helm chart repository.
+3. GitHub repository secrets configured:
+
+   * `DOCKER_HUB_LOGIN` → your Docker Hub username.
+   * `DOCKER_HUB_PWD` → your Docker Hub password or access token.
+4. Your charts must be stored under `./charts/` directory unless you override with the `charts` input.
+
+---
+
+## Inputs
+
+| Name               | Required | Default                           | Description                                                                                                   |
+| ------------------ | -------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `dh-username`      | Yes        | n/a                               | Docker Hub username.                                                                                          |
+| `dh-token`         | Yes        | n/a                               | Docker Hub token or password.                                                                                 |
+| `release-version`  | Yes        | n/a                               | Version to set in each `Chart.yaml` (e.g., `v1.2.3`).                                                         |
+| `charts`           | No        | *(all subfolders of `./charts/`)* | Space-separated list of chart directories to process. If not set, all subfolders inside `./charts/` are used. |
+| `dependent-charts` | No        | `""`                              | Space-separated list of charts that depend on other charts in the same repo.                                  |
+| `dry-run`          | No        | `false`                           | If `true`, the action will print the `helm push` command instead of executing it.                             |
+
+---
+
+## Usage
+
+### Example: Standard Workflow
+
+```yaml
+name: Continuous Deployment
+
+on:
+  push:
+    branches: [main, 'release/**']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Publish Helm Charts
+        uses: 2060-io/devops/actions/publish-helm@main
+        with:
+          dh-username: ${{ secrets.DOCKER_HUB_LOGIN }}
+          dh-token: ${{ secrets.DOCKER_HUB_PWD }}
+          release-version: v1.0.${{ github.run_number }}
+```
+
+---
+
+## Handling Multiple Repositories and Charts
+
+This action supports **both single-chart and multi-chart repositories**:
+
+1. **Multi-chart repository (default):**
+
+   * By default, the action scans all subfolders inside `./charts/`.
+   * Example structure:
+
+     ```
+     ./charts/
+       ├── chatbot/
+       ├── vs-agent/
+     ```
+
+2. **Single chart repository:**
+
+   * If you only want to process one chart, set the `charts` input explicitly:
+
+     ```yaml
+     with:
+       charts: "./charts/my-service"
+     ```
+   * This will only package and publish `./charts/my-service`.
+
+---
+
+## Dependent Charts
+
+If some charts inside your repo depend on other charts in the same repository, you must declare them in the `dependent-charts` input.
+
+* Independent charts will be packaged and published first.
+* Dependent charts will be updated afterward, with their dependencies automatically updated to the new versions.
+
+### Example:
+
+```yaml
+with:
+  release-version: v1.0.${{ github.run_number }}
+  dependent-charts: "./charts/chatbot"
+```
+
+Here, `chatbot` depends on another chart (e.g., `vs-agent`) inside the same repo. The action will:
+
+1. Publish `vs-agent` first.
+2. Then update `chatbot/Chart.yaml` with the correct version of `vs-agent`.
+3. Finally, package and publish `chatbot`.
+
+---
+
+## Dry Run Mode
+
+To validate what would happen without pushing charts:
+
+```yaml
+with:
+  dry-run: true
+```
+
+This will **print the `helm push` commands** instead of executing them. Useful for testing CI/CD pipelines.

--- a/actions/publish-helm/action.yml
+++ b/actions/publish-helm/action.yml
@@ -1,0 +1,116 @@
+name: Publish Helm Charts
+description: Package and publish one or more Helm charts to Docker Hub OCI registry
+
+inputs:
+  dh-username:
+    description: Docker Hub username
+    required: true
+  dh-token:
+    description: Docker Hub token or password
+    required: true
+  release-version:
+    description: The version to set in Chart.yaml (e.g. v1.2.3)
+    required: true
+  charts:
+    description: Space-separated list of chart directories. If not provided, defaults to all subfolders in ./charts/
+    required: false
+    default: ""
+  dependent-charts:
+    description: Space-separated list of chart directories that have dependencies on other charts in this repo
+    required: false
+    default: ""
+  dry-run:
+    description: If true, only print commands instead of executing
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Helm
+      uses: azure/setup-helm@v3
+
+    - name: Log in to Docker Hub Helm Registry
+      shell: bash
+      run: |
+        echo "${{ inputs.dh-token }}" | helm registry login -u "${{ inputs.dh-username }}" --password-stdin docker.io
+
+    - name: Validate chart directories
+      id: validate
+      shell: bash
+      run: |
+        # If no charts provided, take all subfolders of ./charts
+        if [ -z "${{ inputs.charts }}" ]; then
+          CHART_DIRS=$(find ./charts -mindepth 1 -maxdepth 1 -type d | tr '\n' ' ')
+        else
+          CHART_DIRS="${{ inputs.charts }}"
+        fi
+
+        if [ -z "$CHART_DIRS" ]; then
+          echo "No charts found to process"
+          exit 1
+        fi
+
+        echo "Charts to process: $CHART_DIRS"
+        echo "charts=$CHART_DIRS" >> $GITHUB_OUTPUT
+        echo "dependent_charts=${{ inputs.dependent-charts }}" >> $GITHUB_OUTPUT
+
+    - name: Package and push independent charts
+      id: publish_independent
+      shell: bash
+      run: |
+        CHARTS_TO_PROCESS="${{ steps.validate.outputs.charts }}"
+        DEPENDENT_CHARTS="${{ steps.validate.outputs.dependent_charts }}"
+
+        for chart in $CHARTS_TO_PROCESS; do
+          if [[ " $DEPENDENT_CHARTS " == *" $chart "* ]]; then
+            echo "Skipping dependent chart $chart for now"
+            continue
+          fi
+
+          echo "Processing independent chart: $chart"
+          sed -i "s/^version:.*/version: ${{ inputs.release-version }}/" $chart/Chart.yaml
+          CHART_NAME=$(grep '^name:' $chart/Chart.yaml | awk '{print $2}')
+          helm dependency update $chart
+          helm package $chart -d ./charts
+          if [ "${{ inputs.dry-run }}" = "true" ]; then
+            echo "helm push ./charts/${CHART_NAME}-${{ inputs.release-version }}.tgz oci://docker.io/${{ inputs.dh-username }}"
+          else
+            helm push ./charts/${CHART_NAME}-${{ inputs.release-version }}.tgz oci://docker.io/${{ inputs.dh-username }}
+          fi
+
+          echo "$CHART_NAME=${{ inputs.release-version }}" >> $GITHUB_ENV
+        done
+
+    - name: Package and push dependent charts
+      shell: bash
+      run: |
+        DEPENDENT_CHARTS="${{ steps.validate.outputs.dependent_charts }}"
+        if [ -z "$DEPENDENT_CHARTS" ]; then
+          echo "No dependent charts to process"
+          exit 0
+        fi
+
+        for chart in $DEPENDENT_CHARTS; do
+          echo "Processing dependent chart: $chart"
+
+          # update top-level version
+          sed -i "s/^version:.*/version: ${{ inputs.release-version }}/" $chart/Chart.yaml
+
+          # update dependency versions based on env vars we set earlier
+          for dep in $(grep 'name:' $chart/Chart.yaml | awk '{print $2}'); do
+            DEP_VERSION=$(printenv $dep || true)
+            if [ ! -z "$DEP_VERSION" ]; then
+              sed -i "s/\(name: $dep.*\n[[:space:]]*version:\).*/\1 $DEP_VERSION/" $chart/Chart.yaml || true
+            fi
+          done
+
+          CHART_NAME=$(grep '^name:' $chart/Chart.yaml | awk '{print $2}')
+          helm dependency update $chart
+          helm package $chart -d ./charts
+          if [ "${{ inputs.dry-run }}" = "true" ]; then
+            echo "helm push ./charts/${CHART_NAME}-${{ inputs.release-version }}.tgz oci://docker.io/${{ inputs.dh-username }}"
+          else
+            helm push ./charts/${CHART_NAME}-${{ inputs.release-version }}.tgz oci://docker.io/${{ inputs.dh-username }}
+          fi
+        done

--- a/actions/setup-kube/README.md
+++ b/actions/setup-kube/README.md
@@ -1,0 +1,57 @@
+# Setup Kubeconfig GitHub Action
+
+This GitHub Action sets up the Helm CLI and configures access to a Kubernetes cluster using a base64-encoded `kubeconfig`. It is designed to be reused across multiple repositories in your organization.
+
+## Usage
+
+```yaml
+- name: Setup kubeconfig and Helm
+  uses: 2060-io/devops/actions/setup-kube@main
+  with:
+    kubeconfig: ${{ secrets.KUBECONFIG }}
+```
+
+> It's recommended to store your base64-encoded `kubeconfig` as a GitHub secret.
+
+## Inputs
+
+| Name         | Description                                       | Required |
+| ------------ | ------------------------------------------------- | -------- |
+| `kubeconfig` | Base64-encoded KUBECONFIG file for cluster access | ✅ Yes    |
+
+## What it does
+
+1. Installs Helm using the [`azure/setup-helm`](https://github.com/Azure/setup-helm) action.
+2. Decodes the base64-encoded `kubeconfig` into a temporary file inside the GitHub workspace.
+3. Sets the `KUBECONFIG` environment variable so that subsequent steps (e.g., `helm install`) can access the cluster.
+
+## Example with Helm
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup kubeconfig
+        uses: 2060-io/devops/actions/setup-kube@main
+        with:
+          kubeconfig: ${{ secrets.KUBECONFIG }}
+
+      - name: Helm install
+        run: helm upgrade --install my-app ./charts/my-app --namespace default
+```
+
+## Structure
+
+```text
+└── actions/
+    └── setup-kube/
+        └── action.yml
+```
+
+## Security Note
+
+* Always store your `kubeconfig` securely using [GitHub secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets).
+* Avoid committing raw `kubeconfig` files in your repositories.

--- a/actions/setup-kube/action.yml
+++ b/actions/setup-kube/action.yml
@@ -1,0 +1,23 @@
+name: Setup Kubeconfig
+description: |
+  Sets up Helm CLI and configures a Kubernetes cluster using a base64-encoded kubeconfig file.
+author: 2060
+inputs:
+  kubeconfig:
+    description: Base64-encoded kubeconfig for accessing the Kubernetes cluster.
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Helm
+      uses: azure/setup-helm@v3
+
+    - name: Configure KUBECONFIG
+      shell: bash
+      run: |
+        KUBECONFIG_PATH=${{ github.workspace }}/kubeconfig
+        echo "${{ inputs.kubeconfig }}" | base64 -d > "$KUBECONFIG_PATH" || {
+          echo "❌ Failed to decode kubeconfig. Check that the input is valid base64."
+          exit 1
+        }
+        echo "KUBECONFIG=$KUBECONFIG_PATH" >> $GITHUB_ENV


### PR DESCRIPTION
Due we used the repo's open-source with public exposition, GitHub does not allow us to use private actions in a public repo. According to this, we are required to move the actions to an organization repo.