### PR TITLE
feat: add reusable Discord release notify workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -4,11 +4,12 @@ This directory contains **callable GitHub Actions workflows** designed for reuse
 
 ## Callable Workflows
 
-| Workflow File            | Description                | Documentation                        |
-|------------------------- |---------------------------|---------------------------------------|
-| `2060-linter-call.yml`   | Linting workflow          | [docs/2060-linter.md](./docs/2060-linter.md)   |
-| `stable-image-call.yml`  | Build stable Docker image  | [docs/stable-image.md](./docs/stable-image.md) |
-| `unstable-image-call.yml`| Build unstable Docker image| [docs/unstable-image.md](./docs/unstable-image.md) |
+| Workflow File                     | Description                            | Documentation                                                  |
+|---------------------------------- |----------------------------------------|----------------------------------------------------------------|
+| `2060-linter-call.yml`            | Linting workflow                       | [docs/2060-linter.md](./docs/2060-linter.md)                   |
+| `stable-image-call.yml`           | Build stable Docker image              | [docs/stable-image.md](./docs/stable-image.md)                 |
+| `unstable-image-call.yml`         | Build unstable Docker image            | [docs/unstable-image.md](./docs/unstable-image.md)             |
+| `discord-release-notify-call.yml` | Post release notifications to Discord  | [docs/discord-release-notify.md](./docs/discord-release-notify.md) |
 
 ## Usage
 

--- a/.github/workflows/discord-release-notify-call.yml
+++ b/.github/workflows/discord-release-notify-call.yml
@@ -1,0 +1,88 @@
+name: Discord Release Notify
+
+on:
+  workflow_call:
+    secrets:
+      DISCORD_UPDATES_WEBHOOK_URL:
+        description: "Discord channel webhook URL where release notifications are posted. If unset, the workflow exits without posting."
+        required: false
+
+jobs:
+  notify:
+    name: Post release to Discord
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - name: Post release embed
+        env:
+          WEBHOOK_URL: ${{ secrets.DISCORD_UPDATES_WEBHOOK_URL }}
+          REPO_FULL_NAME: ${{ github.repository }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          TAG: ${{ github.event.release.tag_name }}
+          BODY: ${{ github.event.release.body }}
+          URL: ${{ github.event.release.html_url }}
+          PRERELEASE: ${{ github.event.release.prerelease }}
+          PUBLISHED_AT: ${{ github.event.release.published_at }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${WEBHOOK_URL}" ]; then
+            echo "::warning::DISCORD_UPDATES_WEBHOOK_URL is not set, skipping Discord notification."
+            exit 0
+          fi
+
+          if [ -z "${BODY}" ] || [ "${BODY}" = "null" ]; then
+            BODY="(No release notes provided.)"
+          fi
+
+          if [ "${PRERELEASE}" = "true" ]; then
+            COLOR=$((0xf39c12))
+            LABEL="prerelease"
+          else
+            COLOR=$((0x2ecc71))
+            LABEL="stable"
+          fi
+
+          TITLE="${REPO_NAME} ${TAG}"
+          FOOTER="${REPO_FULL_NAME} (${LABEL})"
+
+          PAYLOAD=$(jq -n \
+            --arg title "$TITLE" \
+            --arg description "$BODY" \
+            --arg url "$URL" \
+            --arg footer "$FOOTER" \
+            --arg timestamp "$PUBLISHED_AT" \
+            --argjson color "$COLOR" \
+            '
+            def truncate_body($u):
+              if (. | length) > 3800 then
+                .[0:3800] + "\n\n[View full release on GitHub](" + $u + ")"
+              else
+                .
+              end;
+            {
+              embeds: [
+                {
+                  title: $title,
+                  description: ($description | truncate_body($url)),
+                  url: $url,
+                  color: $color,
+                  footer: { text: $footer },
+                  timestamp: $timestamp
+                }
+              ]
+            }')
+
+          HTTP_CODE=$(curl -sS -o /tmp/discord_response.txt -w "%{http_code}" \
+            -H "Content-Type: application/json" \
+            -X POST \
+            --data "$PAYLOAD" \
+            "$WEBHOOK_URL")
+
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "::error::Discord webhook returned HTTP ${HTTP_CODE}"
+            cat /tmp/discord_response.txt
+            exit 1
+          fi
+
+          echo "Posted release notification for ${TITLE} (HTTP ${HTTP_CODE})."

--- a/.github/workflows/docs/discord-release-notify.md
+++ b/.github/workflows/docs/discord-release-notify.md
@@ -1,0 +1,76 @@
+# Discord Release Notify Workflow Documentation
+
+## Overview
+
+The **Discord Release Notify** workflow posts a Discord embed to a configured webhook whenever a GitHub Release is published in a consuming repository. It supports both stable and prerelease GitHub Releases and renders the release body as the embed description.
+
+It is designed to be invoked as a **reusable workflow** through [`workflow_call`](https://docs.github.com/en/actions/using-workflows/reusing-workflows).
+
+---
+
+## Workflow Triggers
+
+This workflow is triggered via `workflow_call`. The calling workflow is expected to fire on `release: published`:
+
+```yaml
+on:
+  release:
+    types: [published]
+```
+
+### Secrets
+
+* **`DISCORD_UPDATES_WEBHOOK_URL`** *(optional, but required for notifications to actually post)*
+  Discord channel webhook URL. The workflow exits with a warning if this is unset, so it is safe to enable the workflow before the secret is configured.
+
+---
+
+## Behavior
+
+For each published release the workflow posts an embed with:
+
+* **Title:** `${repo_name} ${tag}` (for example `verana-frontend v0.12.0`).
+* **Description:** The release body markdown, truncated to 3800 characters with a "View full release on GitHub" link appended when truncation occurs.
+* **URL:** The release HTML URL.
+* **Color:** Green for stable releases, amber for prereleases.
+* **Footer:** `${owner}/${repo} (stable|prerelease)`.
+* **Timestamp:** The release `published_at`.
+
+The workflow runs only when the calling workflow was triggered by a `release: published` event. Any other event causes the job to be skipped via job-level `if`.
+
+---
+
+## Usage Example
+
+In a consuming repository:
+
+```yaml
+name: Discord Release Notify
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify:
+    uses: 2060-io/organization/.github/workflows/discord-release-notify-call.yml@main
+    secrets: inherit
+```
+
+Then configure `DISCORD_UPDATES_WEBHOOK_URL` either as a repository secret or as an organization secret that grants access to the consuming repository.
+
+---
+
+## Failure Modes
+
+* **Missing webhook URL:** The job logs a workflow warning and exits 0. The release flow is unaffected.
+* **Discord returns non-2xx:** The job logs the HTTP status and response body, then fails. The release itself is unaffected because the notification job runs after the release is already published.
+* **Empty release body:** Replaced with `(No release notes provided.)`.
+* **Very long release body:** Truncated to 3800 characters with a link to the full release.
+
+---
+
+## Notes
+
+* The workflow uses `curl` and `jq` only, both available on `ubuntu-latest` runners. No external action dependencies.
+* The webhook URL is read from `secrets.DISCORD_UPDATES_WEBHOOK_URL`. To use it via an org-level secret, the calling workflow must pass `secrets: inherit`.


### PR DESCRIPTION
Adds a reusable workflow at `.github/workflows/discord-release-notify-call.yml` that posts a Discord embed when a consuming repo publishes a GitHub Release. Stable releases render green, prereleases amber, so one channel can host both. The release body becomes the embed description, truncated at 3800 chars with a link back to the release page.

Webhook URL read from `DISCORD_UPDATES_WEBHOOK_URL`, declared optional so consumers can land their caller before the secret is configured. Consumers pass it through with `secrets: inherit`. Uses `curl` and `jq` only, every event field read via `env:` and never inlined into the run script.

Docs and a README row added. First consumer is `verana-labs/verana-frontend`, follow-up caller PR opened there.
